### PR TITLE
RNMT-2761 Add NSLocationAlwaysUsageDescription tag to location plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Additions
+- Adds NSLocationAlwaysUsageDescription preference to plugin.xml [RNMT-2651](https://outsystemsrd.atlassian.net/browse/RNMT-2651)
+
+## [4.0.1-OS]
+- Fix to allow 4.0.0 version install [CB-13705](https://issues.apache.org/jira/browse/CB-13705)
+
+[Unreleased]: https://github.com/OutSystems/cordova-plugin-geolocation/compare/4.0.1-OS...HEAD
+[4.0.1-OS]: https://github.com/OutSystems/cordova-plugin-geolocation/compare/4.0.1...4.0.1-OS

--- a/plugin.xml
+++ b/plugin.xml
@@ -91,10 +91,13 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <!-- Usage description of the Location for iOS 6+, mandatory since iOS 10 -->
         <preference name="LOCATION_WHENINUSE_USAGE_DESCRIPTION" default=" " />
         <config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
-                <string>$LOCATION_WHENINUSE_USAGE_DESCRIPTION</string>
+            <string>$LOCATION_WHENINUSE_USAGE_DESCRIPTION</string>
         </config-file>
-      
-      
+        
+        <config-file target="*-Info.plist" parent="NSLocationAlwaysUsageDescription">
+            <string>$LOCATION_WHENINUSE_USAGE_DESCRIPTION</string>
+        </config-file>
+
         <header-file src="src/ios/CDVLocation.h" />
         <source-file src="src/ios/CDVLocation.m" />
         <framework src="CoreLocation.framework" />


### PR DESCRIPTION
Mobile application submissions to App Store are being rejected due to `"Missing Purpose String in Info.plist file"` for the `NSLocationAlwaysUsageDescription` key;

This fix adds the preference in plugin.xml and defines the variable using Extensibility Configuration. Also, it adds the CHANGELOG.md file following our standards.