### PR TITLE
RNMT-4280 Handle Permissions Request Cancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixes
+- Method getLocation is no longer called on cancelled permissions request [RNMT-4280](https://outsystemsrd.atlassian.net/browse/RNMT-4280)
 
 ## [4.0.1-OS2]
 

--- a/src/android/Geolocation.java
+++ b/src/android/Geolocation.java
@@ -94,6 +94,12 @@ public class Geolocation extends CordovaPlugin implements OnLocationResultEventL
 
     @Override
     public void onRequestPermissionResult(int requestCode, String[] permissions, int[] grantResults) {
+        // In case a permission request is cancelled, the permissions and grantResults arrays are empty.
+        // We must exit immediately to avoid calling getLocation erroneously.
+        if(permissions == null || permissions.length == 0) {
+            return;
+        }
+
         LocationContext lc = locationContexts.get(requestCode);
 
         for (int grantResult : grantResults) {


### PR DESCRIPTION
When there is a permissions request pending and if another one is made, the last one is cancelled. In practice, that originates a call to `onRequestPermissionResult` method with _permissions_ and _grantResults_ arrays empty, which results in calling `getLocation` method without permissions.

This PR fixes that behaviour, returning immediately if the permission request is a cancelled one.

Fixes https://outsystemsrd.atlassian.net/browse/RNMT-4280