### PR TITLE
RMET-219 Add Watch timeout doesn't stop watch from creating and sending positions

### DIFF
--- a/www/geolocation.js
+++ b/www/geolocation.js
@@ -55,10 +55,13 @@ function parseParameters (options) {
 }
 
 // Returns a timeout failure, closed over a specified timeout value and error callback.
-function createTimeout (errorCallback, timeout) {
+function createTimeout (errorCallback, timeout, isWatch, id) {
     var t = setTimeout(function () {
         clearTimeout(t);
         t = null;
+        if(isWatch === true){
+            geolocation.clearWatch(id);
+        }
         errorCallback({
             code: PositionError.TIMEOUT,
             message: 'Position retrieval timed out.'
@@ -135,7 +138,7 @@ var geolocation = {
                 // If the timeout value was not set to Infinity (default), then
                 // set up a timeout function that will fire the error callback
                 // if no successful position was retrieved before timeout expired.
-                timeoutTimer.timer = createTimeout(fail, options.timeout);
+                timeoutTimer.timer = createTimeout(fail, options.timeout, false, null);
             } else {
                 // This is here so the check in the win function doesn't mess stuff up
                 // may seem weird but this guarantees timeoutTimer is
@@ -174,7 +177,7 @@ var geolocation = {
         var win = function (p) {
             clearTimeout(timers[id].timer);
             if (options.timeout !== Infinity) {
-                timers[id].timer = createTimeout(fail, options.timeout);
+                timers[id].timer = createTimeout(fail, options.timeout, false, null);
             }
             var pos = new Position(
                 {
@@ -197,7 +200,7 @@ var geolocation = {
             // If the timeout value was not set to Infinity (default), then
             // set up a timeout function that will fire the error callback
             // if no successful position was retrieved before timeout expired.
-            timers[id].timer = createTimeout(fail, options.timeout);
+            timers[id].timer = createTimeout(fail, options.timeout, true, id);
         } else {
             // This is here so the check in the win function doesn't mess stuff up
             // may seem weird but this guarantees timeoutTimer is


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
In the JS component of the plugin where the timeout is triggered a check to see if the timeout belongs to a watch is made, if true then it is asked for the watch to be cleared to stop it from returning positions.
## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
 Fixes RMET-219
<!--- Why is this change required? What problem does it solve? -->
When a watch is created a timeout is given, however that timeout is not passed to the native code being only triggered on the JS side, which meant that, before, when a timeout occurred the native code was unaware that it had to stop and remove the newly created watch, this fix addresses that
## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [ ] Android platform
- [ ] iOS platform
- [x] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly