### PR TITLE
RMET-355 - Fix to avoid access location context null

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-geolocation",
-  "version": "4.0.1-OS4",
+  "version": "4.0.1-OS5",
   "description": "Cordova Geolocation Plugin",
   "cordova": {
     "id": "cordova-plugin-geolocation",

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,7 +22,7 @@
 xmlns:rim="http://www.blackberry.com/ns/widgets"
 xmlns:android="http://schemas.android.com/apk/res/android"
            id="cordova-plugin-geolocation"
-      version="4.0.1-OS4">
+      version="4.0.1-OS5">
 
     <name>Geolocation</name>
     <description>Cordova Geolocation Plugin</description>

--- a/src/android/Geolocation.java
+++ b/src/android/Geolocation.java
@@ -112,14 +112,16 @@ public class Geolocation extends CordovaPlugin implements OnLocationResultEventL
             }
         }
 
-        switch(lc.getType()) {
-            case RETRIEVAL:
-                getLocation(lc);
-                break;
+        if (lc != null) {
+            switch(lc.getType()) {
+                case RETRIEVAL:
+                    getLocation(lc);
+                    break;
 
-            case UPDATE:
-                addWatch(lc);
-                break;
+                case UPDATE:
+                    addWatch(lc);
+                    break;
+            }
         }
     }
 

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-geolocation-tests",
-  "version": "4.0.1-OS4",
+  "version": "4.0.1-OS5",
   "description": "",
   "cordova": {
     "id": "cordova-plugin-geolocation-tests",

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -22,7 +22,7 @@
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-geolocation-tests"
-    version="4.0.1-OS4">
+    version="4.0.1-OS5">
     <name>Cordova Geolocation Plugin Tests</name>
     <license>Apache 2.0</license>
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
On Geolocation.java class added a null check to avoid access location context null

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
 Fixes: https://outsystemsrd.atlassian.net/browse/RMET-355 
<!--- Why is this change required? What problem does it solve? -->
This change is necessary to solve a crash after add watch with timeout zero or empty

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [x] Android platform
- [ ] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly