### PR TITLE
RMET-522 GeoLocation - Latitude and Longitude values sometimes have more than 15 digits after decimal point

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-geolocation",
-  "version": "4.0.1-OS5",
+  "version": "4.0.1-OS6",
   "description": "Cordova Geolocation Plugin",
   "cordova": {
     "id": "cordova-plugin-geolocation",

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,7 +22,7 @@
 xmlns:rim="http://www.blackberry.com/ns/widgets"
 xmlns:android="http://schemas.android.com/apk/res/android"
            id="cordova-plugin-geolocation"
-      version="4.0.1-OS5">
+      version="4.0.1-OS6">
 
     <name>Geolocation</name>
     <description>Cordova Geolocation Plugin</description>

--- a/src/ios/CDVLocation.m
+++ b/src/ios/CDVLocation.m
@@ -281,6 +281,10 @@
         // return error
         result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageToErrorObject:POSITIONUNAVAILABLE];
     } else if (lData && lData.locationInfo) {
+        NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
+        [formatter setNumberStyle:NSNumberFormatterDecimalStyle];
+        [formatter setMaximumFractionDigits:15];
+        [formatter setRoundingMode: NSNumberFormatterRoundUp];
         CLLocation* lInfo = lData.locationInfo;
         NSMutableDictionary* returnInfo = [NSMutableDictionary dictionaryWithCapacity:8];
         NSNumber* timestamp = [NSNumber numberWithDouble:([lInfo.timestamp timeIntervalSince1970] * 1000)];
@@ -290,8 +294,8 @@
         [returnInfo setObject:[NSNumber numberWithDouble:lInfo.horizontalAccuracy] forKey:@"accuracy"];
         [returnInfo setObject:[NSNumber numberWithDouble:lInfo.course] forKey:@"heading"];
         [returnInfo setObject:[NSNumber numberWithDouble:lInfo.altitude] forKey:@"altitude"];
-        [returnInfo setObject:[NSNumber numberWithDouble:lInfo.coordinate.latitude] forKey:@"latitude"];
-        [returnInfo setObject:[NSNumber numberWithDouble:lInfo.coordinate.longitude] forKey:@"longitude"];
+        [returnInfo setObject:[formatter stringFromNumber:[NSNumber numberWithDouble:lInfo.coordinate.latitude]] forKey:@"latitude"];
+        [returnInfo setObject:[formatter stringFromNumber:[NSNumber numberWithDouble:lInfo.coordinate.longitude]] forKey:@"longitude"];
 
         result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:returnInfo];
         [result setKeepCallbackAsBool:keepCallback];


### PR DESCRIPTION
# Description
Latitude and Longitude values sometimes have more than 15 digits after decimal point

CLLocationDegrees class uses a double type to store the latitude and longitude values, and the plugin (javascript) stores those in float type variables (half precision).
https://developer.apple.com/documentation/corelocation/cllocationdegrees
So, the digits after the decimal point can be two times longer if compared to the float variable type.
If the plugin is set to high accuracy, there is a good chance to cause this behavior.

The fix uses a NSNumber Formatter, to round up any digits after the 15th digit:

`        NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
        [formatter setNumberStyle:NSNumberFormatterDecimalStyle];
        [formatter setMaximumFractionDigits:15];
        [formatter setRoundingMode: NSNumberFormatterRoundUp];`

## Context
Fixes: https://outsystemsrd.atlassian.net/browse/RMET-522

<!--- Why is this change required? What problem does it solve? -->
Added a NSNumber formatter, to roundup the number after the decimal point to 15 max.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
- [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
- [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
- [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [ ] Android platform
- [x] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
Requested a MABS build on both MABS 6 and 7

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
- [ ] Documentation has been updated accordingly