### PR TITLE
RMET-582 Location Plugin - Fix Android error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2021-04-12
+- Updated location error messages to be more suggestive.
+
 ## [4.0.1-OS3]
 ### Fixes
 - Method getLocation is no longer called on cancelled permissions request [RNMT-4280](https://outsystemsrd.atlassian.net/browse/RNMT-4280)

--- a/src/android/LocationError.java
+++ b/src/android/LocationError.java
@@ -9,7 +9,7 @@ public enum LocationError {
     GOOGLE_SERVICES_ERROR (102, "Google Play Services error"),
     SERIALIZATION_ERROR (103, "Location result serialization error"),
     WATCH_ID_NOT_FOUND (104, "Watch id not found"),
-    LOCATION_SETTINGS_ERROR_RESOLVABLE (105, "Location services are disabled"),
+    LOCATION_SETTINGS_ERROR_RESOLVABLE (105, "Current location settings can not satisfy this request"),
     LOCATION_SETTINGS_ERROR (106, "Location settings error"),
     LOCATION_NULL (107, "Could not retrieve location");
 

--- a/src/android/LocationError.java
+++ b/src/android/LocationError.java
@@ -4,12 +4,12 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 public enum LocationError {
-    LOCATION_PERMISSION_DENIED (100, "Location permission request denied"),
+    LOCATION_PERMISSION_DENIED (100, "Location permission request denied, location services are denied for this app"),
     GOOGLE_SERVICES_ERROR_RESOLVABLE (101, "Google Play Services error user resolvable"),
     GOOGLE_SERVICES_ERROR (102, "Google Play Services error"),
     SERIALIZATION_ERROR (103, "Location result serialization error"),
     WATCH_ID_NOT_FOUND (104, "Watch id not found"),
-    LOCATION_SETTINGS_ERROR_RESOLVABLE (105, "Current location settings can not satisfy this request"),
+    LOCATION_SETTINGS_ERROR_RESOLVABLE (105, "Location services are disabled"),
     LOCATION_SETTINGS_ERROR (106, "Location settings error"),
     LOCATION_NULL (107, "Could not retrieve location");
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Fixed error messages for errors 100 and 105 for Android so that they are more suggestive to the customer.

Error 105 is returned when location services are disabled

Error 100 is returned when location services are denied for the app in specific

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
The way the error messages were written, especially for error 105, did not make it clear to the customer what the error was.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
