### PR TITLE
RMET-608 Location Plugin - Fix GetLocation when location is disabled or location settings need to be changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## 2021-04-27
+- Fix: Fixed requestLocationUpdatesIfSettingsSatisfied method to show the user a dialog to enable location or change location settings (https://outsystemsrd.atlassian.net/browse/RMET-608)
 
 ## [4.0.1-OS3]
 ### Fixes

--- a/src/android/Geolocation.java
+++ b/src/android/Geolocation.java
@@ -5,7 +5,7 @@ import android.content.IntentSender;
 import android.content.pm.PackageManager;
 import android.Manifest;
 import android.location.Location;
-import androidx.annotation.NonNull;
+import android.support.annotation.NonNull;
 
 import android.util.SparseArray;
 

--- a/src/android/Geolocation.java
+++ b/src/android/Geolocation.java
@@ -296,8 +296,6 @@ public class Geolocation extends CordovaPlugin implements OnLocationResultEventL
                     result = new PluginResult(PluginResult.Status.ERROR, LocationError.LOCATION_SETTINGS_ERROR.toJSON());
                     locationContext.getCallbackContext().sendPluginResult(result);
                 }
-
-                //locationContext.getCallbackContext().sendPluginResult(result);
                 locationContexts.remove(locationContext.getId());
             }
         };

--- a/src/android/Geolocation.java
+++ b/src/android/Geolocation.java
@@ -286,6 +286,7 @@ public class Geolocation extends CordovaPlugin implements OnLocationResultEventL
                         ResolvableApiException resolvable = (ResolvableApiException) e;
                         resolvable.startResolutionForResult(cordova.getActivity(),
                                 REQUEST_CHECK_SETTINGS);
+                        requestLocationUpdates(locationContext, request);
                     } catch (IntentSender.SendIntentException sendEx) {
                         // Ignore the error.
                     }

--- a/src/android/Geolocation.java
+++ b/src/android/Geolocation.java
@@ -282,7 +282,8 @@ public class Geolocation extends CordovaPlugin implements OnLocationResultEventL
                     // by showing the user a dialog.
                     try {
                         // Show the dialog by calling startResolutionForResult(),
-                        // and check the result in onActivityResult().
+                        // and check the result in onActivityResult(). We should do this but it is not working
+                        // so for now we simply call for location updates directly, after presenting the dialog
                         ResolvableApiException resolvable = (ResolvableApiException) e;
                         resolvable.startResolutionForResult(cordova.getActivity(),
                                 REQUEST_CHECK_SETTINGS);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Added implementation to the requestLocationUpdatesIfSettingsSatisfied() method to ask the user to either enable location or change location settings, when necessary. Before, we were just returning "Current location settings cannot satisfy this request" error.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
We were simply returning the "Current location settings cannot satisfy this request" error without providing a way to solve the error to the user.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested in local emulators and SauceLab devices for multiple different Android versions

## Screenshots (if appropriate)

Screenshot of the message that will now appear so that users can enable location or change location settings, when necessary:

![image](https://user-images.githubusercontent.com/27646996/116278175-272e5d80-a77e-11eb-8f53-6f9571b3605c.png)



## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [x] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
