### PR TITLE
RMET-918 ::: Return type fix limit decimal digits

### DIFF
--- a/src/ios/CDVLocation.m
+++ b/src/ios/CDVLocation.m
@@ -281,10 +281,6 @@
         // return error
         result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageToErrorObject:POSITIONUNAVAILABLE];
     } else if (lData && lData.locationInfo) {
-        NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
-        [formatter setNumberStyle:NSNumberFormatterDecimalStyle];
-        [formatter setMaximumFractionDigits:15];
-        [formatter setRoundingMode: NSNumberFormatterRoundUp];
         CLLocation* lInfo = lData.locationInfo;
         NSMutableDictionary* returnInfo = [NSMutableDictionary dictionaryWithCapacity:8];
         NSNumber* timestamp = [NSNumber numberWithDouble:([lInfo.timestamp timeIntervalSince1970] * 1000)];
@@ -294,8 +290,16 @@
         [returnInfo setObject:[NSNumber numberWithDouble:lInfo.horizontalAccuracy] forKey:@"accuracy"];
         [returnInfo setObject:[NSNumber numberWithDouble:lInfo.course] forKey:@"heading"];
         [returnInfo setObject:[NSNumber numberWithDouble:lInfo.altitude] forKey:@"altitude"];
-        [returnInfo setObject:[formatter stringFromNumber:[NSNumber numberWithDouble:lInfo.coordinate.latitude]] forKey:@"latitude"];
-        [returnInfo setObject:[formatter stringFromNumber:[NSNumber numberWithDouble:lInfo.coordinate.longitude]] forKey:@"longitude"];
+        
+        //Set maximum decimal digits to 15 for JS float compatibility
+        NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
+        [formatter setMaximumFractionDigits:15];
+        [formatter setRoundingMode: NSNumberFormatterRoundUp];
+        NSString* latitude = [formatter stringFromNumber:[NSNumber numberWithDouble:lInfo.coordinate.latitude]];
+        NSString* longitude = [formatter stringFromNumber:[NSNumber numberWithDouble:lInfo.coordinate.longitude]];
+        
+        [returnInfo setObject:[formatter numberFromString: latitude] forKey:@"latitude"];
+        [returnInfo setObject:[formatter numberFromString: longitude] forKey:@"longitude"];
 
         result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:returnInfo];
         [result setKeepCallbackAsBool:keepCallback];


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Fixed the return type from String to NSNumber limiting it to 15 decimal digits.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
There was a bug on the last fix for limiting the decimal digits where the return type should be a number and in fact was a string

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested in real iOS device

## Screenshots (if appropriate)


## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
- [ ] Documentation has been updated accordingly
