### PR TITLE
RMET-823 Location Plugin - Fix validation for Android 12 permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixes
+- Fixed onRequestPermissionResult method to accept the approximate location option [RMET-823](https://outsystemsrd.atlassian.net/browse/RMET-823)
 
 ## [4.0.1-OS7]
 ### Fixes

--- a/src/android/Geolocation.java
+++ b/src/android/Geolocation.java
@@ -107,26 +107,22 @@ public class Geolocation extends CordovaPlugin implements OnLocationResultEventL
 
         LocationContext lc = locationContexts.get(requestCode);
 
-        if(ArrayUtils.contains(grantResults, PackageManager.PERMISSION_GRANTED)){
-            //do nothing, we have permission to ask for location
-        }
-        else{
+        //if we are granted either ACCESS_COARSE_LOCATION or ACCESS_FINE_LOCATION
+        if (ArrayUtils.contains(grantResults, PackageManager.PERMISSION_GRANTED)) {
+            if (lc != null) {
+                switch (lc.getType()) {
+                    case UPDATE:
+                        addWatch(lc);
+                        break;
+                    default:
+                        getLocation(lc);
+                        break;
+                }
+            }
+        } else {
             PluginResult result = new PluginResult(PluginResult.Status.ILLEGAL_ACCESS_EXCEPTION, LocationError.LOCATION_PERMISSION_DENIED.toJSON());
             lc.getCallbackContext().sendPluginResult(result);
             locationContexts.delete(lc.getId());
-            return;
-        }
-
-        if (lc != null) {
-            switch(lc.getType()) {
-                case RETRIEVAL:
-                    getLocation(lc);
-                    break;
-
-                case UPDATE:
-                    addWatch(lc);
-                    break;
-            }
         }
     }
 

--- a/src/android/Geolocation.java
+++ b/src/android/Geolocation.java
@@ -5,13 +5,14 @@ import android.content.IntentSender;
 import android.content.pm.PackageManager;
 import android.Manifest;
 import android.location.Location;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import android.util.SparseArray;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.common.api.ResolvableApiException;
+import com.google.android.gms.common.util.ArrayUtils;
 import com.google.android.gms.location.FusedLocationProviderClient;
 import com.google.android.gms.location.LocationRequest;
 import com.google.android.gms.location.LocationResult;
@@ -106,14 +107,14 @@ public class Geolocation extends CordovaPlugin implements OnLocationResultEventL
 
         LocationContext lc = locationContexts.get(requestCode);
 
-        for (int grantResult : grantResults) {
-            if (grantResult == PackageManager.PERMISSION_DENIED) {
-
-                PluginResult result = new PluginResult(PluginResult.Status.ILLEGAL_ACCESS_EXCEPTION, LocationError.LOCATION_PERMISSION_DENIED.toJSON());
-                lc.getCallbackContext().sendPluginResult(result);
-                locationContexts.delete(lc.getId());
-                return;
-            }
+        if(ArrayUtils.contains(grantResults, PackageManager.PERMISSION_GRANTED)){
+            //do nothing, we have permission to ask for location
+        }
+        else{
+            PluginResult result = new PluginResult(PluginResult.Status.ILLEGAL_ACCESS_EXCEPTION, LocationError.LOCATION_PERMISSION_DENIED.toJSON());
+            lc.getCallbackContext().sendPluginResult(result);
+            locationContexts.delete(lc.getId());
+            return;
         }
 
         if (lc != null) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Android 12 now lets users decide whether they want to provide FINE (Precise) or COARSE (Approximate) location. So we needed to change our validation in onRequestPermissionResult to handle the case where the user chooses the approximate option.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
Before, we were validating only if the user chose the Precise option. So if the user chose to provide only an approximate location, we would return error "100 : Location permission request denied". Now this error is returned only when the user denies the location request.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested with both MABS 8 NativeShellTemplate and MABS 7.1 build. Both are working for Android 12. Also tested in an Android 11 device.

## Screenshots (if appropriate)


## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [x] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
