### PR TITLE
RMET-964 Location Plugin - Check if LocationContext is null before using it to send error

### DIFF
--- a/src/android/Geolocation.java
+++ b/src/android/Geolocation.java
@@ -120,9 +120,11 @@ public class Geolocation extends CordovaPlugin implements OnLocationResultEventL
                 }
             }
         } else {
-            PluginResult result = new PluginResult(PluginResult.Status.ILLEGAL_ACCESS_EXCEPTION, LocationError.LOCATION_PERMISSION_DENIED.toJSON());
-            lc.getCallbackContext().sendPluginResult(result);
-            locationContexts.delete(lc.getId());
+            if(lc != null){
+                PluginResult result = new PluginResult(PluginResult.Status.ILLEGAL_ACCESS_EXCEPTION, LocationError.LOCATION_PERMISSION_DENIED.toJSON());
+                lc.getCallbackContext().sendPluginResult(result);
+                locationContexts.delete(lc.getId());
+            }
         }
     }
 
@@ -293,8 +295,8 @@ public class Geolocation extends CordovaPlugin implements OnLocationResultEventL
                 else {
                     result = new PluginResult(PluginResult.Status.ERROR, LocationError.LOCATION_SETTINGS_ERROR.toJSON());
                     locationContext.getCallbackContext().sendPluginResult(result);
+                    locationContexts.remove(locationContext.getId());
                 }
-                locationContexts.remove(locationContext.getId());
             }
         };
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- We had a crash in the AddWatch action when the user clicks "Deny" in the Location permission dialog and the timeout already expired. If the user takes too long to Deny the Location permission in the AddWatch action, a timeout error expired error is sent and the LocationContext becomes null. We need to avoid sending the LOCATION_PERMISSION_DENIED error in this case (it would not be shown anyway, the timeout expired error is shown in this case).

- Also moved the code from line 298 inside the else branch. It does not make sense to remove the locationContext in the if case, only in the else case.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
The plugin was causing the app to crash in this very specific case.

References: https://outsystemsrd.atlassian.net/browse/RMET-964

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested with MABS8 Build with NativeShellTemplate. Also tested MABS 7.1 build. Tested in Android 12 and 11.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [x] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
