### PR TITLE
RMET-2893 Location Plugin - Use GPS when wifi and data are off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixes
+- Android: Use LocationManager with GPS when wifi and data are unavailable [RMET-2834](https://outsystemsrd.atlassian.net/browse/RMET-2893)
+
 ## [4.0.1-OS11]
 ### Fixes
 - Fixed Android MABS 10 build by removing android support libraries [RMET-2834](https://outsystemsrd.atlassian.net/browse/RMET-2834)

--- a/plugin.xml
+++ b/plugin.xml
@@ -57,6 +57,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <source-file src="src/android/LocationUtils.java" target-dir="src/org/apache/cordova/geolocation/" />
         <source-file src="src/android/OnLocationResultEventListener.java" target-dir="src/org/apache/cordova/geolocation/" />
         <source-file src="src/android/LocationError.java" target-dir="src/org/apache/cordova/geolocation/" />
+        <source-file src="src/android/LocationHelper.java" target-dir="src/org/apache/cordova/geolocation/" />
 
         <js-module src="www/Coordinates.js" name="Coordinates">
             <clobbers target="Coordinates" />

--- a/src/android/Geolocation.java
+++ b/src/android/Geolocation.java
@@ -201,6 +201,8 @@ public class Geolocation extends CordovaPlugin implements OnLocationResultEventL
             fusedLocationClient.requestLocationUpdates(request, locationContext.getLocationCallback(), null);
         }
         else {
+            //minTime is 0 because we want this call to always return a new location update
+            //minDistance is 0 because we want this call to always return a new location update
             locationHelper.requestGPSLocationUpdates(0, 0, cordova.getContext(), locationContext.getLocationListener());
         }
     }
@@ -239,31 +241,23 @@ public class Geolocation extends CordovaPlugin implements OnLocationResultEventL
     }
 
     private void sendLocationResultSuccess(LocationContext locationContext, Location locationResult) {
+        PluginResult result;
+
         try {
             JSONObject locationObject = LocationUtils.locationToJSON(locationResult);
-            PluginResult result = new PluginResult(PluginResult.Status.OK, locationObject);
-
-            if (locationContext.getType() == LocationContext.Type.UPDATE) {
-                result.setKeepCallback(true);
-            }
-            else {
-                locationContexts.delete(locationContext.getId());
-            }
-
-            locationContext.getCallbackContext().sendPluginResult(result);
-
+            result = new PluginResult(PluginResult.Status.OK, locationObject);
         } catch (JSONException e) {
-            PluginResult result = new PluginResult(PluginResult.Status.JSON_EXCEPTION, LocationError.SERIALIZATION_ERROR.toJSON());
-
-            if (locationContext.getType() == LocationContext.Type.UPDATE) {
-                result.setKeepCallback(true);
-            }
-            else {
-                locationContexts.delete(locationContext.getId());
-            }
-
-            locationContext.getCallbackContext().sendPluginResult(result);
+            result = new PluginResult(PluginResult.Status.JSON_EXCEPTION, LocationError.SERIALIZATION_ERROR.toJSON());
         }
+
+        if (locationContext.getType() == LocationContext.Type.UPDATE) {
+            result.setKeepCallback(true);
+        }
+        else {
+            locationContexts.delete(locationContext.getId());
+        }
+
+        locationContext.getCallbackContext().sendPluginResult(result);
     }
 
     @Override

--- a/src/android/LocationContext.java
+++ b/src/android/LocationContext.java
@@ -1,5 +1,10 @@
 package org.apache.cordova.geolocation;
 
+import android.content.Context;
+import android.location.Location;
+import android.location.LocationListener;
+import android.location.LocationManager;
+import android.os.Bundle;
 import com.google.android.gms.location.LocationCallback;
 import com.google.android.gms.location.LocationResult;
 
@@ -19,8 +24,10 @@ public class LocationContext {
     private CallbackContext callbackContext;
     private LocationCallback locationCallback;
     private final OnLocationResultEventListener listener;
+    private LocationManager locationManager;
+    private LocationListener locationListener;
 
-    public LocationContext(int id, LocationContext.Type type, JSONArray executeArgs, CallbackContext callbackContext, OnLocationResultEventListener listener) {
+    public LocationContext(int id, LocationContext.Type type, JSONArray executeArgs, CallbackContext callbackContext, OnLocationResultEventListener listener, Context context) {
         this.id = id;
         this.type = type;
         this.executeArgs = executeArgs;
@@ -38,6 +45,32 @@ public class LocationContext {
                         LocationContext.this.listener.onLocationResultSuccess(LocationContext.this, locationResult);
                     }
                 }
+            }
+        };
+
+        locationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+        locationListener = new LocationListener() {
+            @Override
+            public void onLocationChanged(Location location) {
+                locationManager.removeUpdates(this);
+                if(LocationContext.this.listener != null) {
+                    LocationContext.this.listener.onLocationGPSResultSuccess(LocationContext.this, location);
+                }
+            }
+
+            @Override
+            public void onStatusChanged(String provider, int status, Bundle extras) {
+                // do nothing
+            }
+
+            @Override
+            public void onProviderEnabled(String provider) {
+                // do nothing
+            }
+
+            @Override
+            public void onProviderDisabled(String provider) {
+                // do nothing
             }
         };
     }
@@ -60,6 +93,10 @@ public class LocationContext {
 
     public LocationCallback getLocationCallback() {
         return locationCallback;
+    }
+
+    public LocationListener getLocationListener() {
+        return locationListener;
     }
 
 }

--- a/src/android/LocationHelper.java
+++ b/src/android/LocationHelper.java
@@ -1,0 +1,20 @@
+package org.apache.cordova.geolocation;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.location.LocationListener;
+import android.location.LocationManager;
+
+public class LocationHelper {
+    private final LocationManager locationManager;
+
+    public LocationHelper(Context context) {
+        locationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+    }
+
+    @SuppressLint("MissingPermission")
+    public void requestGPSLocationUpdates(long minTime, float minDistance, Context context, LocationListener locationListener) {
+        // no need to ask for permission because we already asked for it before this code is reached
+        locationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER, minTime, minDistance, locationListener);
+    }
+}

--- a/src/android/OnLocationResultEventListener.java
+++ b/src/android/OnLocationResultEventListener.java
@@ -1,10 +1,11 @@
 package org.apache.cordova.geolocation;
 
+import android.location.Location;
 import com.google.android.gms.location.LocationResult;
 
 interface OnLocationResultEventListener {
 
     void onLocationResultSuccess(LocationContext locationContext, LocationResult result);
+    void onLocationGPSResultSuccess(LocationContext locationContext, Location result);
     void onLocationResultError(LocationContext locationContext, LocationError error);
-
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- This PR changes the implementation of the GetLocation feature, to use the [`LocationManager`](https://developer.android.com/reference/android/location/LocationManager) when wifi and mobile data are not available.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

- The GetLocation feature was not working in the following use case:
    - With the WIFI/DATA and Location ON, GetLocation returns the location;
    - Turn OFF WIFI, GetLocation returns the location;
    - Turn OFF Location, GetLocation does not return the location, which is expected;
    - Turn Location ON again, GetLocation does not return the location, which is not expected;

- After some investigation, we got to the conclusion that the callback from `FusedLocationProviderClient.requestLocationUpdates` was never called. For that reason, we found an alternative, using `LocationManager.requestLocationUpdates`, explicitly setting it up to use GPS.

References: https://outsystemsrd.atlassian.net/browse/RMET-2834](https://outsystemsrd.atlassian.net/browse/RMET-2893)

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

- Tested with MABS 9, on Android 14, 13, and 12.
- MABS 10 build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=e09c1098d1d213dbe15093237cc2c8600510e599

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
